### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/uv-lock-check-data-preparation.yaml
+++ b/.github/workflows/uv-lock-check-data-preparation.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check uv.lock is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'data_preparation/pyproject.toml'
 
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check requirements.txt is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'data_preparation/pyproject.toml'
           command: 'uv pip compile --python-platform=linux pyproject.toml -o requirements-linux.txt'

--- a/.github/workflows/uv-lock-check-feature-engineering.yaml
+++ b/.github/workflows/uv-lock-check-feature-engineering.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check uv.lock is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'feature_engineering/pyproject.toml'
 
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check requirements.txt is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'feature_engineering/pyproject.toml'
           command: 'uv pip compile --python-platform=linux pyproject.toml -o requirements-linux.txt'

--- a/.github/workflows/uv-lock-check-pipeline.yaml
+++ b/.github/workflows/uv-lock-check-pipeline.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check uv.lock is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'pipeline/pyproject.toml'
 
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check requirements.txt is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'pipeline/pyproject.toml'
           command: 'uv pip compile --python-platform=linux pyproject.toml -o requirements-linux.txt'

--- a/.github/workflows/uv-lock-check-rest-predictor.yaml
+++ b/.github/workflows/uv-lock-check-rest-predictor.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check uv.lock is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'rest_predictor/pyproject.toml'
 
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check requirements.txt is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'rest_predictor/pyproject.toml'
           command: 'uv pip compile --python-platform=linux pyproject.toml -o requirements-linux.txt'

--- a/.github/workflows/uv-lock-check-synthetic-data-generation.yaml
+++ b/.github/workflows/uv-lock-check-synthetic-data-generation.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check uv.lock is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'synthetic_data_generation/pyproject.toml'

--- a/.github/workflows/uv-lock-check-train.yaml
+++ b/.github/workflows/uv-lock-check-train.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check uv.lock is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'train/pyproject.toml'
 
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check requirements.txt is in sync with pyproject.toml
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           pyproject-path: 'train/pyproject.toml'
           command: 'uv pip compile --python-platform=linux pyproject.toml -o requirements-linux.txt'

--- a/.github/workflows/validate-kfp-compiled-files.yaml
+++ b/.github/workflows/validate-kfp-compiled-files.yaml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Check pipelines
-        uses: hbelmiro/validate-kfp-compiled-files@v0.2.0
+        uses: hbelmiro/validate-kfp-compiled-files@6c3966ea26d9c7c8b580d5cb3545b43851c5f271 # v0.2.0
         with:
           pipelines-map-file: './.github/workflows/pipelines.json'
           requirements-file: './pipeline/requirements-linux.txt'


### PR DESCRIPTION
## Summary

- Replace mutable tag references with pinned commit SHAs in all GitHub Actions workflow files
- Original tag is preserved as an inline comment for readability

This improves supply-chain security by ensuring workflows use exact, immutable revisions.